### PR TITLE
hotfix(docs): repair 404 screenshots on the Pages site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ name: Deploy Docs
       - master
     paths:
       - "docs/**"
+      - "assets/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -32,6 +34,12 @@ jobs:
         run: |
           mkdir -p _site
           cp docs/docs.html _site/index.html
+          # docs.html references assets with root relative paths like
+          # `assets/screenshots/X.png`, so mirror the repo's assets
+          # folder into the Pages site root.
+          if [ -d assets ]; then
+            cp -r assets _site/assets
+          fi
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -254,55 +254,55 @@ docker compose up --build</code></pre>
 <p>The dashboard is a React plus Vite SPA served by nginx. Every shot below was captured against a clean <code>docker compose up</code> on the <code>dev</code> branch.</p>
 
 <h3>Sign in</h3>
-<p><img src="../assets/screenshots/01-login.png" alt="Rudra sign in page" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/01-login.png" alt="Rudra sign in page" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Register</h3>
-<p><img src="../assets/screenshots/02-register.png" alt="Register a new admin" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/02-register.png" alt="Register a new admin" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Empty dashboard</h3>
-<p><img src="../assets/screenshots/03-dashboard-empty.png" alt="Dashboard before the first project is created" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/03-dashboard-empty.png" alt="Dashboard before the first project is created" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Pick a plan</h3>
-<p><img src="../assets/screenshots/04-plans.png" alt="Plan picker showing Free, Pro, Business and Enterprise tiers" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/04-plans.png" alt="Plan picker showing Free, Pro, Business and Enterprise tiers" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Configure the project</h3>
-<p><img src="../assets/screenshots/05-project-form.png" alt="Project configuration with name, realm identifier, plan and coupon" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/05-project-form.png" alt="Project configuration with name, realm identifier, plan and coupon" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Project detail</h3>
-<p><img src="../assets/screenshots/06-project-detail.png" alt="Project overview with Users, Applications, SSO, Organizations, Roles, Webhooks and Settings tabs" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/06-project-detail.png" alt="Project overview with Users, Applications, SSO, Organizations, Roles, Webhooks and Settings tabs" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Populated dashboard</h3>
-<p><img src="../assets/screenshots/07-dashboard-populated.png" alt="Dashboard with one project, plan distribution and recent activity" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/07-dashboard-populated.png" alt="Dashboard with one project, plan distribution and recent activity" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Users tab</h3>
-<p><img src="../assets/screenshots/08-project-users.png" alt="Project users tab with search, add user and per row actions" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/08-project-users.png" alt="Project users tab with search, add user and per row actions" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Applications tab</h3>
-<p><img src="../assets/screenshots/09-project-applications.png" alt="Applications tab showing a registered OIDC client" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/09-project-applications.png" alt="Applications tab showing a registered OIDC client" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>SSO tab</h3>
-<p><img src="../assets/screenshots/10-project-sso.png" alt="SSO tab with Add OIDC Provider and Add SAML Provider buttons" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/10-project-sso.png" alt="SSO tab with Add OIDC Provider and Add SAML Provider buttons" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Organizations tab</h3>
-<p><img src="../assets/screenshots/11-project-organizations.png" alt="Organizations tab with an Acme Corp organization card and invite button" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/11-project-organizations.png" alt="Organizations tab with an Acme Corp organization card and invite button" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Roles tab</h3>
-<p><img src="../assets/screenshots/12-project-roles.png" alt="Roles tab with a custom editor role" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/12-project-roles.png" alt="Roles tab with a custom editor role" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Webhooks tab</h3>
-<p><img src="../assets/screenshots/13-project-webhooks.png" alt="Webhooks tab with an endpoint subscribing to user.created, user.deleted and organization.created" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/13-project-webhooks.png" alt="Webhooks tab with an endpoint subscribing to user.created, user.deleted and organization.created" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Settings tab</h3>
-<p><img src="../assets/screenshots/14-project-settings.png" alt="Settings tab with toggles for password auth, social login, magic links, MFA, disposable email blocking, breach detection and bot protection" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/14-project-settings.png" alt="Settings tab with toggles for password auth, social login, magic links, MFA, disposable email blocking, breach detection and bot protection" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Coupons list</h3>
-<p><img src="../assets/screenshots/15-coupons-list.png" alt="Coupons list with active LAUNCH50 and WELCOME10 discounts" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/15-coupons-list.png" alt="Coupons list with active LAUNCH50 and WELCOME10 discounts" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Create coupon modal</h3>
-<p><img src="../assets/screenshots/16-coupon-create-modal.png" alt="Create coupon modal with code, discount percent, max redemptions, description, valid plans and expiry" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/16-coupon-create-modal.png" alt="Create coupon modal with code, discount percent, max redemptions, description, valid plans and expiry" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 
 <h3>Dashboard with a seeded Pro project</h3>
-<p><img src="../assets/screenshots/17-dashboard-pro-project.png" alt="Global dashboard after seeding a Pro project with users, applications, organizations, roles, webhooks and coupons" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
+<p><img src="assets/screenshots/17-dashboard-pro-project.png" alt="Global dashboard after seeding a Pro project with users, applications, organizations, roles, webhooks and coupons" style="max-width:100%; border:1px solid var(--border); border-radius:var(--radius);"></p>
 </section>
 
 <section id="register">


### PR DESCRIPTION
## Summary

The Screenshots section on the deployed documentation site (https://subhrajit-mohanty.github.io/Rudra/) showed broken image icons for all 17 pictures right after 1.1.0 went out.

## Root cause

Two compounding bugs:

1. `docs/docs.html` referenced the screenshots with `../assets/screenshots/...`. That was correct when the file lived at `docs/docs.html` relative to the repo root, but once the deploy workflow copied it to `_site/index.html` it became the Pages root. The `..` then escaped the site root and pointed at `https://subhrajit-mohanty.github.io/assets/...` (no repo prefix), which 404s.
2. `.github/workflows/docs.yml` only copied `docs/docs.html` into `_site/`. The `assets/` folder with the 17 screenshots was never shipped, so even a correct path would still 404.

## Fix

* Stripped the leading `../` from every screenshot `src` attribute in `docs/docs.html` (17 replacements).
* Deploy workflow now mirrors `assets/` into `_site/assets/` before publishing.
* Widened the `paths` trigger on the workflow so a change to `assets/**` or to the workflow itself also redeploys the docs (previously only `docs/**` did).

## Validation

Simulated the published layout locally:

```
/tmp/rudra-site-preview/
  index.html            (copy of docs/docs.html)
  assets/
    screenshots/        (copy of the repo's assets/screenshots/)
```

All 17 `<img src>` paths in `index.html` resolve against that layout (verified with a shell loop that `test -f` each path). After merge, the `Deploy Docs` workflow will redeploy the site with the same layout.

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge, confirm `Deploy Docs` workflow run succeeds
- [ ] Open https://subhrajit-mohanty.github.io/Rudra/ and scroll to the Screenshots section; all 17 images render