### PR TITLE
docs(roadmap): compress to single-quarter v1.2.0 + backlog

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,35 @@
 # Rudra Roadmap
 
-This is the living product roadmap for Rudra, organised into four release milestones. Every bullet below is a real GitHub issue with acceptance criteria, technical approach, dependencies, and references — pick up any one and ship.
+This is the living product roadmap for Rudra, focused on a single-quarter release cadence. The next release (v1.2.0) is ambitious but scoped to roughly twelve weeks of work for a small team. Everything else lives in the [Backlog](#backlog) until v1.2.0 ships.
 
-The current released version is **1.1.0** (April 2026). This roadmap covers four quarterly releases beyond that.
+The current released version is **1.1.0** (April 2026). The next target is **1.2.0** by mid-July 2026.
 
 ## How to read this document
 
-* Four milestones, each mapped to a semver release and a calendar target.
-* Each milestone is grouped by tier so contributors can pick work that matches their interest: foundation plumbing, auth primitives, AI-native features, enterprise, developer experience, polish.
-* Every feature has a short identifier (e.g. `A-1`, `FND-10`) and a matching GitHub issue with full detail.
+* One quarterly milestone. Twenty four issues, each fully scoped with acceptance criteria, technical approach, dependencies, and references.
+* Beyond v1.2.0, items are in the [backlog](#backlog), grouped by tier so they can be promoted into v1.3.0 when the next quarter opens.
 * Effort markers: **S** under a week, **M** one to three weeks, **L** over a month, **XL** over a quarter.
-* Priority markers: **P0** (ship first), **P1** (early), **P2** (later), **P3** (defer if tight).
+* Priority markers: **P0** ship first, **P1** ship early, **P2** ship later in the milestone, **P3** defer if tight.
 
 ## Where to look first
 
-* Browse by milestone: [Milestones](https://github.com/subhrajit-mohanty/Rudra/milestones).
+* Browse the milestone: [v1.2.0](https://github.com/subhrajit-mohanty/Rudra/milestone/1).
 * Filter by tier: [tier:foundation](https://github.com/subhrajit-mohanty/Rudra/labels/tier%3Afoundation), [tier:auth](https://github.com/subhrajit-mohanty/Rudra/labels/tier%3Aauth), [tier:ai-native](https://github.com/subhrajit-mohanty/Rudra/labels/tier%3Aai-native), [tier:enterprise](https://github.com/subhrajit-mohanty/Rudra/labels/tier%3Aenterprise), [tier:devex](https://github.com/subhrajit-mohanty/Rudra/labels/tier%3Adevex), [tier:novel](https://github.com/subhrajit-mohanty/Rudra/labels/tier%3Anovel), [tier:polish](https://github.com/subhrajit-mohanty/Rudra/labels/tier%3Apolish).
 * Filter by priority: [priority:p0-critical](https://github.com/subhrajit-mohanty/Rudra/labels/priority%3Ap0-critical), [priority:p1-high](https://github.com/subhrajit-mohanty/Rudra/labels/priority%3Ap1-high).
-* Good first issues: effort `S` items tagged with `priority:p2-medium` or lower are the easiest starting points.
+* Backlog (no milestone): [issues with no milestone](https://github.com/subhrajit-mohanty/Rudra/issues?q=is%3Aissue+is%3Aopen+no%3Amilestone).
+* Good first issues: effort `S` items tagged `priority:p2-medium` or lower.
 
 ---
 
-## v1.2.0 — Foundation and first-hour wins
+## v1.2.0 - Production-ready quarter
 
-**Target:** 2026-07-15 · **Milestone:** [v1.2.0](https://github.com/subhrajit-mohanty/Rudra/milestone/1)
+**Target:** 2026-07-15 · **Milestone:** [v1.2.0](https://github.com/subhrajit-mohanty/Rudra/milestone/1) · **Scope:** 24 issues
 
-**Theme:** every feature the product advertises actually works, observability is live, and the complaints a developer voices in their first hour are gone.
+**Theme:** every feature the product advertises actually works, ops can observe and operate the system, modern auth ships (passkeys, step-up, OTP, MFA recovery, account-protection), and developer first-hour friction is gone. Anything that does not directly serve those goals lives in the backlog until v1.2.0 lands.
 
-### Security and trust (7 items)
+### Foundation: trust repair and ops hygiene (12 items)
+
+These twelve items remove the gap between what Rudra advertises and what Rudra does. Without them, every other feature rests on sand.
 
 | ID | Title | Effort | Priority |
 |---|---|---|---|
@@ -38,188 +40,136 @@ The current released version is **1.1.0** (April 2026). This roadmap covers four
 | FND-7 | [Implement bot protection via Cloudflare Turnstile](https://github.com/subhrajit-mohanty/Rudra/issues/8) | S | P0 |
 | FND-8 | [HMAC-SHA256 signatures for webhook deliveries](https://github.com/subhrajit-mohanty/Rudra/issues/9) | S | P0 |
 | FND-9 | [Migrate remaining 25 endpoints to _get_owned_tenant helper](https://github.com/subhrajit-mohanty/Rudra/issues/10) | S | P1 |
-
-### Scale and ops hygiene (4 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
 | FND-1 | [Cache Keycloak admin token in Redis](https://github.com/subhrajit-mohanty/Rudra/issues/11) | S | P0 |
 | FND-2 | [Share a single httpx.AsyncClient with connection pooling](https://github.com/subhrajit-mohanty/Rudra/issues/12) | S | P0 |
 | FND-11 | [Real /api/health that checks Mongo, Keycloak, Redis](https://github.com/subhrajit-mohanty/Rudra/issues/13) | S | P1 |
 | FND-4 | [Background queue for webhook delivery with retries and DLQ](https://github.com/subhrajit-mohanty/Rudra/issues/14) | M | P1 |
 | FND-12 | [Prometheus metrics and OpenTelemetry tracing](https://github.com/subhrajit-mohanty/Rudra/issues/15) | M | P1 |
 
-### Developer first-hour (3 items)
+### Modern auth that evaluators look for in the first hour (5 items)
+
+| ID | Title | Effort | Priority |
+|---|---|---|---|
+| A-1 | [Passkeys / WebAuthn support](https://github.com/subhrajit-mohanty/Rudra/issues/19) | M | P1 |
+| A-4 | [Step-up authentication for sensitive operations](https://github.com/subhrajit-mohanty/Rudra/issues/21) | S | P1 |
+| A-8 | [Email OTP and SMS OTP as alternatives to magic links](https://github.com/subhrajit-mohanty/Rudra/issues/22) | S | P1 |
+| A-11 | [MFA recovery flows (backup codes, recovery email, admin unlock)](https://github.com/subhrajit-mohanty/Rudra/issues/23) | S | P1 |
+| C-9 | [GDPR data subject access requests (export and deletion)](https://github.com/subhrajit-mohanty/Rudra/issues/34) | S | P2 |
+
+### Quality of life and rollout safety (4 items)
 
 | ID | Title | Effort | Priority |
 |---|---|---|---|
 | D-5 | [Publish auto-generated OpenAPI spec and versioned releases](https://github.com/subhrajit-mohanty/Rudra/issues/16) | S | P1 |
 | D-6 | [Webhook replay in dashboard and local tunnel in CLI](https://github.com/subhrajit-mohanty/Rudra/issues/17) | S | P2 |
 | P-1 | [In-dashboard email template editor with live preview](https://github.com/subhrajit-mohanty/Rudra/issues/18) | S | P2 |
+| E-5 | [Per-tenant feature flags](https://github.com/subhrajit-mohanty/Rudra/issues/33) | S | P1 |
 
----
-
-## v1.3.0 — Hosted components and enterprise unlock
-
-**Target:** 2026-10-15 · **Milestone:** [v1.3.0](https://github.com/subhrajit-mohanty/Rudra/milestone/2)
-
-**Theme:** drop-in React components turn a three-day integration into thirty minutes. First F500 RFPs close. Modern auth primitives (passkeys, step-up, account linking, OTP, MFA recovery) all ship.
-
-### Modern auth primitives (6 items)
+### Stretch goals (3 items, ship if quarter has slack)
 
 | ID | Title | Effort | Priority |
 |---|---|---|---|
-| A-1 | [Passkeys / WebAuthn support](https://github.com/subhrajit-mohanty/Rudra/issues/19) | M | P1 |
-| A-3 | [Account linking across password, social and passkeys](https://github.com/subhrajit-mohanty/Rudra/issues/20) | M | P1 |
-| A-4 | [Step-up authentication for sensitive operations](https://github.com/subhrajit-mohanty/Rudra/issues/21) | S | P1 |
-| A-8 | [Email OTP and SMS OTP as alternatives to magic links](https://github.com/subhrajit-mohanty/Rudra/issues/22) | S | P1 |
-| A-11 | [MFA recovery flows (backup codes, recovery email, admin unlock)](https://github.com/subhrajit-mohanty/Rudra/issues/23) | S | P1 |
 | A-12 | [Service account tokens for CI/CD and server-to-server](https://github.com/subhrajit-mohanty/Rudra/issues/24) | S | P2 |
-
-### Integration friction (3 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| A-2 | [Hosted UI components (<SignIn />, <UserButton />, ...)](https://github.com/subhrajit-mohanty/Rudra/issues/25) | XL | P1 |
-| A-10 | [Framework SDKs (rudra-fastapi, rudra-django, rudra-nextjs, rudra-express)](https://github.com/subhrajit-mohanty/Rudra/issues/26) | M | P2 |
+| C-5 | [Immutable tamper-evident audit logs (hash-chained)](https://github.com/subhrajit-mohanty/Rudra/issues/31) | S | P2 |
 | D-1 | [rudra CLI for login, resource management, logs, webhook tunnel](https://github.com/subhrajit-mohanty/Rudra/issues/27) | M | P2 |
 
-### Enterprise unlock (5 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| C-1 | [SCIM 2.0 provisioning endpoint](https://github.com/subhrajit-mohanty/Rudra/issues/28) | M | P1 |
-| C-2 | [Organization-level SSO (per-org IdP routing by email domain)](https://github.com/subhrajit-mohanty/Rudra/issues/29) | M | P1 |
-| C-4 | [Audit log streaming to S3, Datadog, Splunk, OCSF](https://github.com/subhrajit-mohanty/Rudra/issues/30) | M | P1 |
-| C-5 | [Immutable tamper-evident audit logs (hash-chained)](https://github.com/subhrajit-mohanty/Rudra/issues/31) | S | P2 |
-| C-10 | [IP allowlisting and geo-fencing per tenant](https://github.com/subhrajit-mohanty/Rudra/issues/32) | S | P2 |
-
-### Rollout machinery (2 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| E-5 | [Per-tenant feature flags](https://github.com/subhrajit-mohanty/Rudra/issues/33) | S | P1 |
-| C-9 | [GDPR data subject access requests (export and deletion)](https://github.com/subhrajit-mohanty/Rudra/issues/34) | S | P2 |
-
 ---
 
-## v2.0.0 — AI-native differentiation
+## Backlog
 
-**Target:** 2027-01-15 · **Milestone:** [v2.0.0](https://github.com/subhrajit-mohanty/Rudra/milestone/3)
+Thirty eight fully scoped issues, parked until v1.2.0 ships. Each is ready to be picked up the moment the next quarter opens. Listed by tier so contributors can browse to the area they want to work on.
 
-**Theme:** plant the 2026 flag that no open-source auth product has planted yet. Agent identity, MCP OAuth, policy assistant, explainable risk. The pitch moves from "open-source Clerk" to "first auth platform built for the agent era."
+### Modern auth and B2B identity
 
-### Authorization foundation (2 items, build first in the quarter)
+| ID | Title | Effort |
+|---|---|---|
+| A-2 | [Hosted UI components (`<SignIn />`, `<UserButton />`, ...)](https://github.com/subhrajit-mohanty/Rudra/issues/25) | XL |
+| A-3 | [Account linking across password, social and passkeys](https://github.com/subhrajit-mohanty/Rudra/issues/20) | M |
+| A-5 | [Adaptive risk-based authentication](https://github.com/subhrajit-mohanty/Rudra/issues/36) | M |
+| A-6 | [Custom domains per tenant](https://github.com/subhrajit-mohanty/Rudra/issues/45) | L |
+| A-7 | [Fine-grained authorization (ReBAC) with POST /api/check](https://github.com/subhrajit-mohanty/Rudra/issues/35) | L |
+| A-10 | [Framework SDKs (rudra-fastapi, rudra-django, rudra-nextjs, rudra-express)](https://github.com/subhrajit-mohanty/Rudra/issues/26) | M |
 
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| A-7 | [Fine-grained authorization (ReBAC) with POST /api/check](https://github.com/subhrajit-mohanty/Rudra/issues/35) | L | P0 |
-| A-5 | [Adaptive risk-based authentication](https://github.com/subhrajit-mohanty/Rudra/issues/36) | M | P0 |
+### AI-native auth
 
-### Agent primitives (5 items, on top of A-7)
+| ID | Title | Effort |
+|---|---|---|
+| B-1 | [Agents as first-class principals](https://github.com/subhrajit-mohanty/Rudra/issues/37) | M |
+| B-2 | [OAuth 2.0 authorization server for MCP servers](https://github.com/subhrajit-mohanty/Rudra/issues/38) | L |
+| B-3 | [Human-in-the-loop approval workflows](https://github.com/subhrajit-mohanty/Rudra/issues/39) | M |
+| B-4 | [Per-tool scoped tokens with minute-level expiry](https://github.com/subhrajit-mohanty/Rudra/issues/40) | M |
+| B-5 | [Agent audit log with intent capture](https://github.com/subhrajit-mohanty/Rudra/issues/41) | S |
+| B-6 | [AI policy assistant - natural language to ReBAC](https://github.com/subhrajit-mohanty/Rudra/issues/42) | M |
+| B-7 | [Natural-language audit log queries](https://github.com/subhrajit-mohanty/Rudra/issues/43) | M |
+| B-8 | [Explainable risk score UI](https://github.com/subhrajit-mohanty/Rudra/issues/44) | S |
 
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| B-1 | [Agents as first-class principals](https://github.com/subhrajit-mohanty/Rudra/issues/37) | M | P0 |
-| B-2 | [OAuth 2.0 authorization server for MCP servers](https://github.com/subhrajit-mohanty/Rudra/issues/38) | L | P1 |
-| B-3 | [Human-in-the-loop approval workflows](https://github.com/subhrajit-mohanty/Rudra/issues/39) | M | P1 |
-| B-4 | [Per-tool scoped tokens with minute-level expiry](https://github.com/subhrajit-mohanty/Rudra/issues/40) | M | P1 |
-| B-5 | [Agent audit log with intent capture](https://github.com/subhrajit-mohanty/Rudra/issues/41) | S | P2 |
+### Enterprise and compliance
 
-### AI features (3 items, on top of ReBAC and adaptive auth)
+| ID | Title | Effort |
+|---|---|---|
+| C-1 | [SCIM 2.0 provisioning endpoint](https://github.com/subhrajit-mohanty/Rudra/issues/28) | M |
+| C-2 | [Organization-level SSO](https://github.com/subhrajit-mohanty/Rudra/issues/29) | M |
+| C-3 | [Organization hierarchies (parent / child orgs)](https://github.com/subhrajit-mohanty/Rudra/issues/54) | M |
+| C-4 | [Audit log streaming to S3, Datadog, Splunk, OCSF](https://github.com/subhrajit-mohanty/Rudra/issues/30) | M |
+| C-6 | [Data residency in US / EU / APAC (start)](https://github.com/subhrajit-mohanty/Rudra/issues/51) | XL |
+| C-7 | [Customer-managed encryption keys (BYOK)](https://github.com/subhrajit-mohanty/Rudra/issues/49) | M |
+| C-8 | [Compliance pack (SOC 2 / GDPR / HIPAA preset)](https://github.com/subhrajit-mohanty/Rudra/issues/50) | M |
+| C-10 | [IP allowlisting and geo-fencing per tenant](https://github.com/subhrajit-mohanty/Rudra/issues/32) | S |
+| C-11 | [Organization-scoped API keys](https://github.com/subhrajit-mohanty/Rudra/issues/55) | M |
+| C-12 | [Dark web monitoring for tenant user credentials](https://github.com/subhrajit-mohanty/Rudra/issues/56) | S |
 
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| B-6 | [AI policy assistant — natural language to ReBAC](https://github.com/subhrajit-mohanty/Rudra/issues/42) | M | P2 |
-| B-7 | [Natural-language audit log queries](https://github.com/subhrajit-mohanty/Rudra/issues/43) | M | P2 |
-| B-8 | [Explainable risk score UI](https://github.com/subhrajit-mohanty/Rudra/issues/44) | S | P2 |
+### Developer experience
 
-### Platform polish (4 items)
+| ID | Title | Effort |
+|---|---|---|
+| D-2 | [Terraform provider and Helm chart](https://github.com/subhrajit-mohanty/Rudra/issues/46) | M |
+| D-3 | [Migration tools from Auth0, Clerk, Firebase](https://github.com/subhrajit-mohanty/Rudra/issues/58) | L |
+| D-4 | [Additional SDKs: Go, Java, Ruby, .NET, PHP](https://github.com/subhrajit-mohanty/Rudra/issues/57) | L |
+| D-7 | [Auth flow playground in the dashboard](https://github.com/subhrajit-mohanty/Rudra/issues/47) | M |
+| D-8 | [Self-service diagnostic dump](https://github.com/subhrajit-mohanty/Rudra/issues/48) | S |
+| D-9 | [Visual workflow builder for auth flows](https://github.com/subhrajit-mohanty/Rudra/issues/59) | L |
 
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| A-6 | [Custom domains per tenant](https://github.com/subhrajit-mohanty/Rudra/issues/45) | L | P1 |
-| D-2 | [Terraform provider and Helm chart](https://github.com/subhrajit-mohanty/Rudra/issues/46) | M | P2 |
-| D-7 | [Auth flow playground in the dashboard](https://github.com/subhrajit-mohanty/Rudra/issues/47) | M | P2 |
-| D-8 | [Self-service diagnostic dump](https://github.com/subhrajit-mohanty/Rudra/issues/48) | S | P3 |
+### Commercial and novel
 
----
+| ID | Title | Effort |
+|---|---|---|
+| E-3 | [Consent ledger with user-facing receipts](https://github.com/subhrajit-mohanty/Rudra/issues/53) | M |
+| E-4 | [Stripe-backed metered billing for plans and MAU](https://github.com/subhrajit-mohanty/Rudra/issues/52) | M |
 
-## v2.1.0 — Compliance, commercial, scale
+### Polish and scale
 
-**Target:** 2027-04-15 · **Milestone:** [v2.1.0](https://github.com/subhrajit-mohanty/Rudra/milestone/4)
+| ID | Title | Effort |
+|---|---|---|
+| P-5 | [Real-time dashboard updates via WebSockets](https://github.com/subhrajit-mohanty/Rudra/issues/64) | S |
+| P-6 | [Read replicas and per-tenant Mongo sharding](https://github.com/subhrajit-mohanty/Rudra/issues/60) | L |
+| P-7 | [Backup and restore workflows](https://github.com/subhrajit-mohanty/Rudra/issues/61) | M |
+| P-9 | [WCAG 2.1 AA audit and fixes for hosted UI](https://github.com/subhrajit-mohanty/Rudra/issues/62) | M |
+| P-10 | [i18n harness and first non-English locale](https://github.com/subhrajit-mohanty/Rudra/issues/63) | M |
 
-**Theme:** move from "startups love it" to "enterprises standardise on it." Compliance packs, BYOK, data residency start, Stripe billing, additional language SDKs, migration tools, a11y and i18n.
+### Documentation
 
-### Compliance (3 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| C-7 | [Customer-managed encryption keys (BYOK) for PII](https://github.com/subhrajit-mohanty/Rudra/issues/49) | M | P1 |
-| C-8 | [Compliance pack (SOC 2 / GDPR / HIPAA preset)](https://github.com/subhrajit-mohanty/Rudra/issues/50) | M | P1 |
-| C-6 | [Data residency in US / EU / APAC (start)](https://github.com/subhrajit-mohanty/Rudra/issues/51) | XL | P1 |
-
-### Commercial (4 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| E-4 | [Stripe-backed metered billing for plans and MAU](https://github.com/subhrajit-mohanty/Rudra/issues/52) | M | P1 |
-| E-3 | [Consent ledger with user-facing receipts](https://github.com/subhrajit-mohanty/Rudra/issues/53) | M | P2 |
-| C-3 | [Organization hierarchies (parent / child orgs)](https://github.com/subhrajit-mohanty/Rudra/issues/54) | M | P2 |
-| C-11 | [Organization-scoped API keys](https://github.com/subhrajit-mohanty/Rudra/issues/55) | M | P2 |
-| C-12 | [Dark web monitoring for tenant user credentials](https://github.com/subhrajit-mohanty/Rudra/issues/56) | S | P2 |
-
-### Scale and developer breadth (5 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| D-4 | [Additional SDKs: Go, Java, Ruby, .NET, PHP](https://github.com/subhrajit-mohanty/Rudra/issues/57) | L | P1 |
-| D-3 | [Migration tools from Auth0, Clerk, Firebase](https://github.com/subhrajit-mohanty/Rudra/issues/58) | L | P2 |
-| D-9 | [Visual workflow builder for auth flows](https://github.com/subhrajit-mohanty/Rudra/issues/59) | L | P3 |
-| P-6 | [Read replicas and per-tenant Mongo sharding](https://github.com/subhrajit-mohanty/Rudra/issues/60) | L | P2 |
-| P-7 | [Backup and restore workflows](https://github.com/subhrajit-mohanty/Rudra/issues/61) | M | P2 |
-
-### Accessibility, i18n, real-time (3 items)
-
-| ID | Title | Effort | Priority |
-|---|---|---|---|
-| P-9 | [WCAG 2.1 AA audit and fixes for hosted UI](https://github.com/subhrajit-mohanty/Rudra/issues/62) | M | P2 |
-| P-10 | [i18n harness and first non-English locale](https://github.com/subhrajit-mohanty/Rudra/issues/63) | M | P2 |
-| P-5 | [Real-time dashboard updates via WebSockets](https://github.com/subhrajit-mohanty/Rudra/issues/64) | S | P3 |
+| ID | Title | Effort |
+|---|---|---|
+| #3 | [docs: auto-stamp the release version into the published docs](https://github.com/subhrajit-mohanty/Rudra/issues/3) | S |
 
 ---
 
 ## Explicitly deferred
 
-A few ideas considered but deliberately held back:
+These ideas were considered and held back deliberately. They do not have issues filed; promote them by writing one.
 
 * **Cross-tenant identity portability (BYO-Identity).** Beautiful network-effect idea. Requires product-market fit first; revisit in year two.
 * **Continuous authentication (behavioural biometrics).** High false-positive risk without dedicated ML. Wait for stronger data infrastructure.
 * **GraphQL API alongside REST.** OpenAPI gives most of the benefit. Two surfaces to maintain for unclear payoff.
-* **China / Russia data residency regions.** Different regulatory animal; covered by acknowledging the issue, deferred on scope.
-* **Full SOC 2 Type II audit certification.** The compliance pack (C-8) prepares the tenant; the actual audit is a customer-side exercise for now.
 
 ## Working with the roadmap
 
 **For maintainers:**
-* Add a feature to an existing milestone before adding a new milestone.
-* Keep milestones date-bound and under a quarter of real work.
+* Add a feature to v1.2.0 only if it directly advances the quarterly theme. Otherwise file in the backlog.
+* Promote a backlog item to the next milestone (v1.3.0) only after v1.2.0 ships.
 * Close an issue only when its Acceptance Criteria all tick. No "done enough" closures.
 
 **For contributors:**
 * Pick any unassigned issue; comment "I'd like to take this" and a maintainer will assign it.
 * Ship on a `dev` branch. Never push directly to `master`; the repo's CI only runs on PRs into `master`.
 * The full validation procedure and contribution guidelines live in [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Setting up a Projects v2 board (optional)
-
-The roadmap above is fully navigable via milestones and labels without a Projects v2 board. If you want a kanban-style view, create one manually (one-time setup, approximately 5 minutes):
-
-1. Go to https://github.com/users/subhrajit-mohanty/projects and click **New project** → **Board**.
-2. Name: "Rudra Roadmap".
-3. Add fields: `Quarter` (single select: v1.2.0, v1.3.0, v2.0.0, v2.1.0), `Tier` (from the tier labels), `Priority` (P0–P3), `Effort` (S/M/L/XL).
-4. Add existing issues: **+ Add item** → filter `is:issue milestone:v1.2.0` and bulk add. Repeat per milestone.
-5. Create views: Kanban by Status, Roadmap by Quarter, Table all-in.
-6. Done.
-
-If Projects v2 CLI scope becomes useful, `gh auth refresh -s project` opens a browser and grants the scope; a future issue can automate board creation via `gh project create`.


### PR DESCRIPTION
## Summary

Compresses the roadmap from a year-long four-milestone plan into a single quarterly release (v1.2.0) plus a backlog. Picks the highest-value issues from the existing 61 and parks the rest until v1.2.0 ships.

## What changed on GitHub before this PR

I already applied the milestone changes via the GitHub API so the PR diff is just the docs:

* **v1.2.0 grew from 15 to 24 issues.** Promoted nine: A-1 passkeys, A-4 step-up, A-8 OTP, A-11 MFA recovery, C-9 GDPR DSAR, A-12 service accounts, D-1 CLI, E-5 feature flags, C-5 immutable audit (the last three as stretch).
* **38 issues moved to backlog (no milestone).** Browsable at [no:milestone open](https://github.com/subhrajit-mohanty/Rudra/issues?q=is%3Aissue+is%3Aopen+no%3Amilestone).
* **v1.3.0, v2.0.0, v2.1.0 milestones deleted.** They were empty after the moves.
* **v1.2.0 renamed to "Production-ready quarter"** with a refreshed description.

## Why one quarter, not four

* Keeps the team focused on shipping rather than spreading effort across a year.
* Every item in v1.2.0 directly advances either "the product does what it advertises" or "an evaluator says yes in the first hour".
* The backlog preserves all 38 lower-priority issues verbatim. Only the cadence of delivery changed.

## What is in v1.2.0

| Group | Count | Notes |
|---|---|---|
| Foundation | 12 | All FND-* items. Without these, plan flags are lies and ops cannot operate. |
| Modern auth (must-have) | 5 | A-1 Passkeys, A-4 Step-up, A-8 OTP, A-11 MFA recovery, C-9 GDPR DSAR. |
| Quality of life and rollout | 4 | D-5 OpenAPI publish, D-6 Webhook replay, P-1 Email editor, E-5 Feature flags. |
| Stretch (P2, S/M effort) | 3 | A-12 Service accounts, C-5 Immutable audit, D-1 CLI. |

## Test plan

- [ ] CI checks pass on this PR.
- [ ] After merge, ROADMAP.md on master shows the single-quarter focus.
- [ ] Milestones page shows only [v1.2.0](https://github.com/subhrajit-mohanty/Rudra/milestones).
- [ ] [Backlog query](https://github.com/subhrajit-mohanty/Rudra/issues?q=is%3Aissue+is%3Aopen+no%3Amilestone) returns the 38 backlog items.

## Out of scope

This PR does not file any new issues, change any issue body, or change CI. It updates ROADMAP.md to reflect milestone changes already made through the GitHub API.